### PR TITLE
dotnetcore-windowshosting: remove references to IIS Express

### DIFF
--- a/dotnetcore-windowshosting/dotnetcore-windowshosting.nuspec
+++ b/dotnetcore-windowshosting/dotnetcore-windowshosting.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>dotnetcore-windowshosting</id>
-    <version>2.0.6.20180315</version>
+    <version>2.0.6.20180320</version>
     <packageSourceUrl>https://github.com/dotnetcore-chocolatey/dotnetcore-chocolateypackages/tree/master/dotnetcore-windowshosting</packageSourceUrl>
     <owners>jberezanski,riezebosch</owners>
     <title>Microsoft .NET Core - Windows Server Hosting</title>
@@ -15,18 +15,18 @@
     <docsUrl>https://docs.microsoft.com/dotnet</docsUrl>
     <bugTrackerUrl>https://www.microsoft.com/net/support</bugTrackerUrl>
     <tags>microsoft .net core runtime redistributable asp.net module ancm iis admin</tags>
-    <summary>This package installs the ASP.NET Core Module for IIS and/or IIS Express, enabling hosting of ASP.NET Core applications.</summary>
+    <summary>This package installs the ASP.NET Core Module for IIS, enabling hosting of ASP.NET Core applications.</summary>
     <description>
 .NET Core is a general purpose development platform maintained by Microsoft and the .NET community on GitHub. It is cross-platform, supporting Windows, macOS and Linux, and can be used in device, cloud, and embedded/IoT scenarios.
 
-This package installs the ASP.NET Core Module for IIS and/or IIS Express, enabling running of ASP.NET Core applications. IIS must be enabled and/or IIS Express must be installed prior to installing this package. ASP.NET Core does not use any managed IIS modules, so no ASP.NET IIS features need to be enabled.
+This package installs the ASP.NET Core Module for IIS, enabling running of ASP.NET Core applications. IIS must be enabled prior to installing this package. ASP.NET Core does not use any managed IIS modules, so no ASP.NET IIS features need to be enabled.
 
 The native installer is instructed to skip installing the .NET Core Runtime (`OPT_INSTALL_LTS_REDIST=0 OPT_INSTALL_FTS_REDIST=0`). The package [dotnetcore-runtime](https://chocolatey.org/packages/dotnetcore-runtime) should be used to install the runtime when hosting ["portable"](https://docs.microsoft.com/en-us/dotnet/articles/core/deploying/index) ASP.NET Core applications (which use the machine-wide runtime). Hosting of ["self-contained"](https://docs.microsoft.com/en-us/dotnet/articles/core/deploying/index) ASP.NET Core applications does not require the runtime to be installed, because those applications include the desired runtime as part of their binaries.
 
 The package supports the following parameters (--package-parameters, --params):
 
 - `Quiet` - suppress display of native installer progress window (may be needed on Server Core)
-- `IgnoreMissingIIS` - allow package installation even if neither full IIS nor IIS Express is present (probably useless, as the native installer will not install anything)
+- `IgnoreMissingIIS` - allow package installation even if IIS is not present (probably useless, as the native installer will not install anything)
 
 Example: cinst -y --params="Quiet IgnoreMissingIIS" dotnetcore-windowshosting
 </description>
@@ -34,7 +34,7 @@ Example: cinst -y --params="Quiet IgnoreMissingIIS" dotnetcore-windowshosting
 ##### Software
 [.NET Core Release Notes](https://github.com/dotnet/core/tree/master/release-notes)
 ##### Package
-Dependency update on runtime package store.
+Removed references to IIS Express.
     </releaseNotes>
     <dependencies>
       <dependency id="chocolatey-core.extension" version="1.1.0" />

--- a/dotnetcore-windowshosting/tools/ChocolateyInstall.ps1
+++ b/dotnetcore-windowshosting/tools/ChocolateyInstall.ps1
@@ -30,23 +30,16 @@ function Test-IisInstalled
     return $iisInstalled
 }
 
-function Test-IisExpressInstalled
-{
-    $iisExpressInstalled = Test-Path -Path (Join-Path -Path $Env:ProgramFiles -ChildPath 'IIS Express\iisexpress.exe')
-    return $iisExpressInstalled
-}
-
-function Ensure-IisOrIisExpressInstalled
+function Ensure-IisInstalled
 {
     $iisInstalled = Test-IisInstalled
-    $iisExpressInstalled = Test-IisExpressInstalled
 
-    if (-not $iisInstalled -and -not $iisExpressInstalled) {
+    if (-not $iisInstalled) {
         $ignoreMissingIisKeyword = 'IgnoreMissingIIS'
         if ($Env:chocolateyPackageParameters -notlike "*$ignoreMissingIisKeyword*") {
-            throw "Neither IIS nor IIS Express is installed. Install at least one of them before installing this package, or pass '$ignoreMissingIisKeyword' as package parameter to force the installation anyway."
+            throw "IIS is not installed. Install at least one of them before installing this package, or pass '$ignoreMissingIisKeyword' as package parameter to force the installation anyway."
         } else {
-            Write-Warning "Neither IIS nor IIS Express is installed, but proceeding with the installation because '$ignoreMissingIisKeyword' was passed as package parameter."
+            Write-Warning "IIS is not installed, but proceeding with the installation because '$ignoreMissingIisKeyword' was passed as package parameter."
         }
     }
 
@@ -54,11 +47,6 @@ function Ensure-IisOrIisExpressInstalled
         Write-Verbose 'IIS is enabled.'
     } else {
         Write-Warning 'IIS is not enabled. The ASP.NET Core Module for IIS requires IIS to be enabled before installing the module. To install the module, enable IIS and install this package again using the --force switch.'
-    }
-    if ($iisExpressInstalled) {
-        Write-Verbose 'IIS Express is installed.'
-    } else {
-        Write-Verbose 'IIS Express is not installed.'
     }
 }
 
@@ -83,7 +71,7 @@ function Get-PassiveOrQuietArgument
     return $passiveOrQuiet
 }
 
-Ensure-IisOrIisExpressInstalled
+Ensure-IisInstalled
 
 $passiveOrQuiet = Get-PassiveOrQuietArgument -Scenario 'installation'
 $arguments = @{


### PR DESCRIPTION
Related to #12.

As discussed in https://github.com/dotnet/core/issues/848, the hosting
bundle installer does not actually contain the module for IIS Express.
No idea what gave the impression that it did back when this package was
created.