### PR TITLE
make regexes in AU stream definitions more robust

### DIFF
--- a/dotnetcore-runtime.install/Update.ps1
+++ b/dotnetcore-runtime.install/Update.ps1
@@ -32,10 +32,10 @@ function global:au_GetLatest {
 
       @{
          Streams = [ordered] @{
-             '2.1' = EntryToData($json | where { $_.'version-runtime' -match '^2.1.\d+$' } | sort { $_.'version-runtime' -as [version] } -Descending | select -First 1)
-             '2.0' = EntryToData($json | where { $_.'version-runtime' -match '^2.0.\d+$' } | sort { $_.'version-runtime' -as [version] } -Descending | select -First 1)
-             '1.1' = EntryToData($json | where { $_.'version-runtime' -match '^1.1.\d+$' } | sort { $_.'version-runtime' -as [version] } -Descending | select -First 1)
-             '1.0' = EntryToData($json | where { $_.'version-runtime' -match '^1.0.\d+$' } | sort { $_.'version-runtime' -as [version] } -Descending | select -First 1)
+             '2.1' = EntryToData($json | where { $_.'version-runtime' -match '^2\.1\.\d+$' } | sort { $_.'version-runtime' -as [version] } -Descending | select -First 1)
+             '2.0' = EntryToData($json | where { $_.'version-runtime' -match '^2\.0\.\d+$' } | sort { $_.'version-runtime' -as [version] } -Descending | select -First 1)
+             '1.1' = EntryToData($json | where { $_.'version-runtime' -match '^1\.1\.\d+$' } | sort { $_.'version-runtime' -as [version] } -Descending | select -First 1)
+             '1.0' = EntryToData($json | where { $_.'version-runtime' -match '^1\.0\.\d+$' } | sort { $_.'version-runtime' -as [version] } -Descending | select -First 1)
         }
     }
 }

--- a/dotnetcore-sdk/Update.ps1
+++ b/dotnetcore-sdk/Update.ps1
@@ -27,9 +27,9 @@ function global:au_GetLatest {
 
       @{
          Streams = [ordered] @{
-             '2.1-preview' = EntryToData($json | where { $_.'version-sdk' -match '^2.1.\d+-.*$' } | sort { [datetime]$_.'date' } -Descending | select -First 1)
-             '2.1' = EntryToData($json | where { $_.'version-sdk' -match '^2.1.\d+$' } | sort { $_.'version-sdk' -as [version] } -Descending | select -First 1)
-             '1.1' = EntryToData($json | where { $_.'version-sdk' -match '^1.1.\d+$' } | sort { $_.'version-sdk' -as [version] } -Descending | select -First 1)
+             '2.1-preview' = EntryToData($json | where { $_.'version-sdk' -match '^2\.1\.\d+-.*$' } | sort { [datetime]$_.'date' } -Descending | select -First 1)
+             '2.1' = EntryToData($json | where { $_.'version-sdk' -match '^2\.1\.\d+$' } | sort { $_.'version-sdk' -as [version] } -Descending | select -First 1)
+             '1.1' = EntryToData($json | where { $_.'version-sdk' -match '^1\.1\.\d+$' } | sort { $_.'version-sdk' -as [version] } -Descending | select -First 1)
         }
     }
 }


### PR DESCRIPTION
Dots in version prefixes ("2.1.") should be matched literally, not as
"any character".

Otherwise, problems will arise once one of the version segments reaches
10.